### PR TITLE
MINOR: add obsolete keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "silverstripe",
     "framework",
     "database",
-    "utility"
+    "utility",
+    "obsolete"
   ],
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Amazing module!  adding obsolete keyword may make it easier to find.